### PR TITLE
Fix MoldUDP64 requested message count

### DIFF
--- a/src/main/java/org/jvirtanen/nassau/moldudp64/MoldUDP64Client.java
+++ b/src/main/java/org/jvirtanen/nassau/moldudp64/MoldUDP64Client.java
@@ -121,7 +121,7 @@ public class MoldUDP64Client implements Closeable {
         highestReceivedSequenceNumber = Math.max(highestReceivedSequenceNumber, lastSequenceNumber);
 
         if (sequenceNumber > nextExpectedSequenceNumber) {
-            int requestedMessageCount = (int)Math.min(sequenceNumber - nextExpectedSequenceNumber + 1,
+            int requestedMessageCount = (int)Math.min(highestReceivedSequenceNumber - nextExpectedSequenceNumber,
                     MAX_MESSAGE_COUNT);
 
             if (state == SYNCHRONIZED)

--- a/src/test/java/org/jvirtanen/nassau/moldudp64/MoldUDP64ClientTest.java
+++ b/src/test/java/org/jvirtanen/nassau/moldudp64/MoldUDP64ClientTest.java
@@ -67,6 +67,7 @@ public class MoldUDP64ClientTest {
 
         packet.clear();
         packet.put(wrap("baz"));
+        packet.put(wrap("quux"));
 
         server.nextSequenceNumber = 3;
         server.send(packet);
@@ -85,21 +86,22 @@ public class MoldUDP64ClientTest {
         packet.put(wrap("foo"));
         packet.put(wrap("bar"));
         packet.put(wrap("baz"));
+        packet.put(wrap("quux"));
 
         server.nextSequenceNumber = 1;
         server.send(packet);
 
         packet.clear();
-        packet.put(wrap("quux"));
+        packet.put(wrap("xyzzy"));
 
-        server.nextSequenceNumber = 4;
+        server.nextSequenceNumber = 5;
         server.send(packet);
 
-        while (clientMessages.collect().size() != 4)
+        while (clientMessages.collect().size() != 5)
             client.receive();
 
-        assertEquals(asList("foo", "bar", "baz", "quux"), clientMessages.collect());
-        assertEquals(asList(new State(BACKFILL), new Request(1, 2), new Request(1, 3),
+        assertEquals(asList("foo", "bar", "baz", "quux", "xyzzy"), clientMessages.collect());
+        assertEquals(asList(new State(BACKFILL), new Request(1, 2), new Request(1, 4),
                     new Downstream(), new State(SYNCHRONIZED), new Downstream(),
                     new Downstream()), clientStatus.collect());
     }


### PR DESCRIPTION
Instead of limiting the requested message count to include only the first sequence number in the current downstream packet, limit it so that it includes the highest received sequence number.