### PR TITLE
Add SoupBinTCP gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ See the [Wiki][] for links to the protocol specifications.
 
 Besides the library, Nassau contains the following applications:
 
+  - [**SoupBinTCP Gateway**](nassau-soupbintcp-gateway) bridges the MoldUDP64
+    protocol to the SoupBinTCP protocol.
+
   - [**SoupBinTCP Performance Test**](nassau-soupbintcp-perf-test) is a simple
     latency benchmark for the SoupBinTCP implementation.
 

--- a/nassau-soupbintcp-gateway/README.md
+++ b/nassau-soupbintcp-gateway/README.md
@@ -1,0 +1,22 @@
+Nassau SoupBinTCP Gateway
+=========================
+
+Nassau SoupBinTCP Gateway bridges the NASDAQ MoldUDP64 1.00 protocol to the
+NASDAQ SoupBinTCP 3.00 protocol.
+
+
+Usage
+-----
+
+Run Nassau SoupBinTCP Gateway with Java:
+
+    java -jar <executable> <configuration-file>
+
+When started, the gateway starts listening for SoupBinTCP sessions initiated
+by clients.
+
+
+License
+-------
+
+Nassau SoupBinTCP Gateway is released under the Apache License, Version 2.0.

--- a/nassau-soupbintcp-gateway/etc/devel.conf
+++ b/nassau-soupbintcp-gateway/etc/devel.conf
@@ -1,0 +1,11 @@
+upstream {
+  multicast-interface = 127.0.0.1
+  multicast-group     = 224.0.0.1
+  multicast-port      = 4001
+  request-address     = 127.0.0.1
+  request-port        = 4002
+}
+
+downstream {
+  port = 4001
+}

--- a/nassau-soupbintcp-gateway/pom.xml
+++ b/nassau-soupbintcp-gateway/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jvirtanen.nassau</groupId>
+    <artifactId>nassau-parent</artifactId>
+    <version>0.6.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nassau-soupbintcp-gateway</artifactId>
+
+  <name>Nassau SoupBinTCP Gateway</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>nassau</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.typesafe</groupId>
+      <artifactId>config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jvirtanen.config</groupId>
+      <artifactId>config-extras</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <transformers>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+              <mainClass>org.jvirtanen.nassau.soupbintcp.gateway.Gateway</mainClass>
+            </transformer>
+          </transformers>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/nassau-soupbintcp-gateway/src/main/java/org/jvirtanen/soupbintcp/gateway/DownstreamServer.java
+++ b/nassau-soupbintcp-gateway/src/main/java/org/jvirtanen/soupbintcp/gateway/DownstreamServer.java
@@ -1,0 +1,49 @@
+package org.jvirtanen.nassau.soupbintcp.gateway;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.StandardSocketOptions;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import org.jvirtanen.nassau.MessageListener;
+import org.jvirtanen.nassau.soupbintcp.SoupBinTCP;
+import org.jvirtanen.nassau.soupbintcp.SoupBinTCPServer;
+import org.jvirtanen.nassau.soupbintcp.SoupBinTCPServerStatusListener;
+
+class DownstreamServer {
+
+    private UpstreamFactory upstream;
+
+    private ServerSocketChannel serverChannel;
+
+    private DownstreamServer(UpstreamFactory upstream, ServerSocketChannel serverChannel) {
+        this.upstream      = upstream;
+        this.serverChannel = serverChannel;
+    }
+
+    public static DownstreamServer open(UpstreamFactory upstream, int port) throws IOException {
+        ServerSocketChannel serverChannel = ServerSocketChannel.open();
+
+        serverChannel.bind(new InetSocketAddress(port));
+        serverChannel.configureBlocking(false);
+
+        return new DownstreamServer(upstream, serverChannel);
+    }
+
+    public ServerSocketChannel getServerChannel() {
+        return serverChannel;
+    }
+
+    public Session accept() throws IOException {
+        SocketChannel downstream = serverChannel.accept();
+        if (downstream == null)
+            return null;
+
+        downstream.setOption(StandardSocketOptions.TCP_NODELAY, true);
+        downstream.configureBlocking(false);
+
+        return new Session(upstream, downstream);
+    }
+
+}

--- a/nassau-soupbintcp-gateway/src/main/java/org/jvirtanen/soupbintcp/gateway/Events.java
+++ b/nassau-soupbintcp-gateway/src/main/java/org/jvirtanen/soupbintcp/gateway/Events.java
@@ -1,0 +1,129 @@
+package org.jvirtanen.nassau.soupbintcp.gateway;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.util.ArrayList;
+import java.util.List;
+
+class Events {
+
+    private static final int TIMEOUT = 500;
+
+    public static void process(DownstreamServer downstream) throws IOException {
+        Selector selector = Selector.open();
+
+        final List<Session> toKeepAlive = new ArrayList<>();
+        final List<Session> toCleanUp   = new ArrayList<>();
+
+        downstream.getServerChannel().register(selector, SelectionKey.OP_ACCEPT);
+
+        while (true) {
+            int numKeys = selector.select(TIMEOUT);
+
+            if (numKeys > 0) {
+                for (SelectionKey key : selector.selectedKeys()) {
+                    if (key.isAcceptable()) {
+                        final Session session = downstream.accept();
+                        if (session == null)
+                            continue;
+
+                        session.getDownstream().getChannel().register(selector,
+                                SelectionKey.OP_READ, new Receiver() {
+
+                                    @Override
+                                    public void close() {
+                                        toCleanUp.add(session);
+                                    }
+
+                                    @Override
+                                    public void receive() throws IOException {
+                                        session.getDownstream().receive();
+                                    }
+
+                                });
+
+                        session.getUpstream().getChannel().register(selector,
+                                SelectionKey.OP_READ, new Receiver() {
+
+                                    @Override
+                                    public void close() {
+                                        toCleanUp.add(session);
+                                    }
+
+                                    @Override
+                                    public void receive() throws IOException {
+                                        session.getUpstream().receive();
+                                    }
+
+                                });
+
+                        session.getUpstream().getRequestChannel().register(selector,
+                                SelectionKey.OP_READ, new Receiver() {
+
+                                    @Override
+                                    public void close() {
+                                        toCleanUp.add(session);
+                                    }
+
+                                    @Override
+                                    public void receive() throws IOException {
+                                        session.getUpstream().receiveResponse();
+                                    }
+
+                                });
+
+                        toKeepAlive.add(session);
+                    } else {
+                        Receiver receiver = (Receiver)key.attachment();
+
+                        try {
+                            receiver.receive();
+                        } catch (IOException e1) {
+                            try {
+                                receiver.close();
+                            } catch (IOException e2) {
+                            }
+                        }
+                    }
+                }
+
+                selector.selectedKeys().clear();
+            }
+
+            for (int i = 0; i < toKeepAlive.size(); i++) {
+                Session session = toKeepAlive.get(i);
+
+                try {
+                    session.getDownstream().keepAlive();
+                } catch (IOException e) {
+                    toCleanUp.add(session);
+                }
+            }
+
+            if (toCleanUp.isEmpty())
+                continue;
+
+            for (int i = 0; i < toCleanUp.size(); i++) {
+                Session session = toCleanUp.get(i);
+
+                toKeepAlive.remove(session);
+
+                try {
+                    session.close();
+                } catch (IOException e) {
+                }
+            }
+
+            toCleanUp.clear();
+        }
+    }
+
+    private interface Receiver extends Closeable {
+
+        void receive() throws IOException;
+
+    }
+
+}

--- a/nassau-soupbintcp-gateway/src/main/java/org/jvirtanen/soupbintcp/gateway/Gateway.java
+++ b/nassau-soupbintcp-gateway/src/main/java/org/jvirtanen/soupbintcp/gateway/Gateway.java
@@ -1,0 +1,80 @@
+package org.jvirtanen.nassau.soupbintcp.gateway;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import org.jvirtanen.config.Configs;
+
+class Gateway {
+
+    public static void main(String[] args) {
+        if (args.length != 1)
+            usage();
+
+        try {
+            main(config(args[0]));
+        } catch (ConfigException | FileNotFoundException e) {
+            error(e);
+        } catch (IOException e) {
+            fatal(e);
+        }
+    }
+
+    private static void main(Config config) throws IOException {
+        UpstreamFactory  upstream   = upstream(config);
+        DownstreamServer downstream = downstream(config, upstream);
+
+        Events.process(downstream);
+    }
+
+    private static UpstreamFactory upstream(Config config) {
+        NetworkInterface multicastInterface = Configs.getNetworkInterface(config, "upstream.multicast-interface");
+        InetAddress      multicastGroup     = Configs.getInetAddress(config, "upstream.multicast-group");
+        int              multicastPort      = Configs.getPort(config, "upstream.multicast-port");
+        InetAddress      requestAddress     = Configs.getInetAddress(config, "upstream.request-address");
+        int              requestPort        = Configs.getPort(config, "upstream.request-port");
+
+        return new UpstreamFactory(multicastInterface, new InetSocketAddress(multicastGroup, multicastPort),
+                new InetSocketAddress(requestAddress, requestPort));
+    }
+
+    private static DownstreamServer downstream(Config config, UpstreamFactory upstream) throws IOException {
+        int port = Configs.getPort(config, "downstream.port");
+
+        return DownstreamServer.open(upstream, port);
+    }
+
+    private static void usage() {
+        System.err.println("Usage: soupbintcp-gateway <configuration-file>");
+        System.exit(2);
+    }
+
+    private static Config config(String filename) throws FileNotFoundException {
+        File file = new File(filename);
+
+        if (!file.exists() || !file.isFile())
+            throw new FileNotFoundException(filename + ": No such file");
+
+        return ConfigFactory.parseFile(file);
+    }
+
+    private static void error(Throwable throwable) {
+        System.err.println("error: " + throwable.getMessage());
+        System.exit(1);
+    }
+
+    private static void fatal(Throwable throwable) {
+        System.err.println("fatal: " + throwable.getMessage());
+        System.err.println();
+        throwable.printStackTrace(System.err);
+        System.err.println();
+        System.exit(1);
+    }
+
+}

--- a/nassau-soupbintcp-gateway/src/main/java/org/jvirtanen/soupbintcp/gateway/Session.java
+++ b/nassau-soupbintcp-gateway/src/main/java/org/jvirtanen/soupbintcp/gateway/Session.java
@@ -1,0 +1,62 @@
+package org.jvirtanen.nassau.soupbintcp.gateway;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import org.jvirtanen.nassau.MessageListener;
+import org.jvirtanen.nassau.moldudp64.MoldUDP64Client;
+import org.jvirtanen.nassau.soupbintcp.SoupBinTCP;
+import org.jvirtanen.nassau.soupbintcp.SoupBinTCPServer;
+import org.jvirtanen.nassau.soupbintcp.SoupBinTCPServerStatusListener;
+
+class Session implements Closeable, MessageListener, SoupBinTCPServerStatusListener {
+
+    private static SoupBinTCP.LoginAccepted loginAccepted = new SoupBinTCP.LoginAccepted();
+
+    private MoldUDP64Client  upstream;
+    private SoupBinTCPServer downstream;
+
+    public Session(UpstreamFactory upstream, SocketChannel downstream) throws IOException {
+        this.downstream = new SoupBinTCPServer(downstream, this, this);
+        this.upstream   = upstream.create(this.downstream);
+    }
+
+    @Override
+    public void close() throws IOException {
+        upstream.close();
+        downstream.close();
+    }
+
+    @Override
+    public void message(ByteBuffer buffer) throws IOException {
+        close();
+    }
+
+    @Override
+    public void heartbeatTimeout() throws IOException {
+        close();
+    }
+
+    @Override
+    public void loginRequest(SoupBinTCP.LoginRequest payload) throws IOException {
+        loginAccepted.session        = payload.requestedSession;
+        loginAccepted.sequenceNumber = payload.requestedSequenceNumber;
+
+        downstream.accept(loginAccepted);
+    }
+
+    @Override
+    public void logoutRequest() throws IOException {
+        close();
+    }
+
+    public MoldUDP64Client getUpstream() {
+        return upstream;
+    }
+
+    public SoupBinTCPServer getDownstream() {
+        return downstream;
+    }
+
+}

--- a/nassau-soupbintcp-gateway/src/main/java/org/jvirtanen/soupbintcp/gateway/UpstreamFactory.java
+++ b/nassau-soupbintcp-gateway/src/main/java/org/jvirtanen/soupbintcp/gateway/UpstreamFactory.java
@@ -1,0 +1,75 @@
+package org.jvirtanen.nassau.soupbintcp.gateway;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.StandardProtocolFamily;
+import java.net.StandardSocketOptions;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+import org.jvirtanen.nassau.MessageListener;
+import org.jvirtanen.nassau.moldudp64.MoldUDP64Client;
+import org.jvirtanen.nassau.moldudp64.MoldUDP64ClientState;
+import org.jvirtanen.nassau.moldudp64.MoldUDP64ClientStatusListener;
+import org.jvirtanen.nassau.soupbintcp.SoupBinTCPServer;
+
+class UpstreamFactory {
+
+    private NetworkInterface  multicastInterface;
+    private InetSocketAddress multicastGroup;
+    private InetSocketAddress requestAddress;
+
+    public UpstreamFactory(NetworkInterface multicastInterface,
+            InetSocketAddress multicastGroup, InetSocketAddress requestAddress) {
+        this.multicastInterface = multicastInterface;
+        this.multicastGroup     = multicastGroup;
+        this.requestAddress     = requestAddress;
+    }
+
+    public MoldUDP64Client create(final SoupBinTCPServer downstream) throws IOException {
+        DatagramChannel channel = DatagramChannel.open(StandardProtocolFamily.INET);
+
+        channel.setOption(StandardSocketOptions.SO_REUSEADDR, true);
+        channel.bind(new InetSocketAddress(multicastGroup.getPort()));
+        channel.join(multicastGroup.getAddress(), multicastInterface);
+        channel.configureBlocking(false);
+
+        DatagramChannel requestChannel = DatagramChannel.open(StandardProtocolFamily.INET);
+
+        requestChannel.configureBlocking(false);
+
+        MessageListener listener = new MessageListener() {
+
+            @Override
+            public void message(ByteBuffer buffer) throws IOException {
+                downstream.send(buffer);
+            }
+
+        };
+
+        MoldUDP64ClientStatusListener statusListener = new MoldUDP64ClientStatusListener() {
+
+            @Override
+            public void state(MoldUDP64ClientState next) {
+            }
+
+            @Override
+            public void downstream() {
+            }
+
+            @Override
+            public void request(long sequenceNumber, int requestedMessageCount) {
+            }
+
+            @Override
+            public void endOfSession() throws IOException {
+                downstream.endSession();
+            }
+
+        };
+
+        return new MoldUDP64Client(channel, requestChannel, requestAddress,
+                listener, statusListener);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -46,12 +46,18 @@
 
   <modules>
     <module>nassau</module>
+    <module>nassau-soupbintcp-gateway</module>
     <module>nassau-soupbintcp-perf-test</module>
     <module>nassau-binaryfile-perf-test</module>
   </modules>
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>com.typesafe</groupId>
+        <artifactId>config</artifactId>
+        <version>1.3.0</version>
+      </dependency>
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
@@ -61,6 +67,11 @@
         <groupId>org.hdrhistogram</groupId>
         <artifactId>HdrHistogram</artifactId>
         <version>2.1.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jvirtanen.config</groupId>
+        <artifactId>config-extras</artifactId>
+        <version>0.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.jvirtanen.nio</groupId>
@@ -132,7 +143,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <excludePackageNames>*.perf</excludePackageNames>
+          <excludePackageNames>org.jvirtanen.nassau.soupbintcp.gateway:*.perf</excludePackageNames>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
The SoupBinTCP gateway bridges the MoldUDP64 protocol to the SoupBinTCP protocol.

MoldUDP64 is based on multicast transmission, which is often not possible on cloud infrastructure. SoupBinTCP, on the other hand, is based on unicast transmission.